### PR TITLE
Support devices runing KitKat (API 19) #6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionNameApp
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation 'at.favre.lib:armadillo:0.4.3'
+    implementation project(':armadillo')
     implementation "com.android.support:appcompat-v7:$rootProject.ext.dependencies.support"
     testImplementation "junit:junit:$rootProject.ext.dependencies.junit"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/armadillo/src/main/java/at/favre/lib/armadillo/AuthenticatedEncryption.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/AuthenticatedEncryption.java
@@ -39,7 +39,9 @@ public interface AuthenticatedEncryption {
      *
      * @param rawEncryptionKey to use as encryption key material
      * @param rawData          to encrypt
-     * @param associatedData   additional data used to create the auth tag and will be subject to integrity/authentication check
+     * @param associatedData   additional data used to create the auth tag and will be subject to
+     *                         integrity/authentication check (associatedData is not available on
+     *                         Android KitKat (API level 19), it will be ignored)
      * @return encrypted content
      * @throws AuthenticatedEncryptionException if any crypto fails
      */
@@ -51,7 +53,8 @@ public interface AuthenticatedEncryption {
      * @param rawEncryptionKey to use as decryption key material
      * @param encryptedData    to decrypt
      * @param associatedData   additional data used to create the auth tag; must be same as provided
-     *                         in the encrypt step
+     *                         in the encrypt step (associatedData is not available on Android KitKat
+     *                         (API level 19), it will be ignored)
      * @return decrypted, original data
      * @throws AuthenticatedEncryptionException if any crypto fails
      */

--- a/armadillo/src/main/java/at/favre/lib/armadillo/Utils.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/Utils.java
@@ -1,0 +1,17 @@
+package at.favre.lib.armadillo;
+
+import android.os.Build;
+
+class Utils {
+
+    private Utils() {
+        // Utility class
+    }
+
+    /**
+     * Checks whether the device runs Android KitKat (API level 19).
+     */
+    static boolean isKitKat() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
+    }
+}


### PR DESCRIPTION
- Init cipher using [IvParameterSpec](https://developer.android.com/reference/javax/crypto/spec/IvParameterSpec) instead of [GCMParameterSpec](https://developer.android.com/reference/javax/crypto/spec/GCMParameterSpec) on devices running KitKat.
- Ignore associated data on devices running KitKat.