### PR TITLE
Migrate to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,41 +1,45 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    compileOptions {
+        sourceCompatibility androidConfig.javaVersion
+        targetCompatibility androidConfig.javaVersion
+    }
+
+    compileSdkVersion androidConfig.compileSdkVersion
+    buildToolsVersion androidConfig.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.versionCode
-        versionName rootProject.ext.versionNameApp
-
         applicationId "at.favre.lib.securesharedpreferences"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        minSdkVersion androidConfig.minSdkVersion
+        targetSdkVersion androidConfig.targetSdkVersion
+        versionCode versionCode
+        versionName versionNameApp
+        testInstrumentationRunner androidConfig.testInstrumentationRunner
     }
+
     dataBinding {
         enabled = true
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig debug.signingConfig // TODO create release key keystore
         }
-    }
-    compileOptions {
-        sourceCompatibility rootProject.ext.javaVersion
-        targetCompatibility rootProject.ext.javaVersion
     }
 }
 
 dependencies {
     implementation project(':armadillo')
-    implementation "com.android.support:appcompat-v7:$rootProject.ext.dependencies.support"
-    implementation "com.android.support:design:$rootProject.ext.dependencies.support"
-    implementation "com.android.support:cardview-v7:$rootProject.ext.dependencies.support"
-    implementation "com.android.support.constraint:constraint-layout:$rootProject.ext.dependencies.constraintLayout"
-    implementation "com.facebook.stetho:stetho:$rootProject.ext.dependencies.stetho"
-    testImplementation "junit:junit:$rootProject.ext.dependencies.junit"
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:$rootProject.ext.dependencies.espresso"
+    implementation appDependencies.appCompat
+    implementation appDependencies.constraintLayout
+    implementation appDependencies.cardView
+    implementation appDependencies.materialComponents
+    implementation appDependencies.stetho
+    testImplementation testDependencies.junit
+    testImplementation testDependencies.testRunner
+    testImplementation testDependencies.espresso
 }

--- a/app/src/main/java/at/favre/lib/securesharedpreferences/ChangePasswordActivity.java
+++ b/app/src/main/java/at/favre/lib/securesharedpreferences/ChangePasswordActivity.java
@@ -1,9 +1,9 @@
 package at.favre.lib.securesharedpreferences;
 
 import android.content.Intent;
-import android.databinding.DataBindingUtil;
+import androidx.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 
 import at.favre.lib.armadillo.Armadillo;

--- a/app/src/main/java/at/favre/lib/securesharedpreferences/MainActivity.java
+++ b/app/src/main/java/at/favre/lib/securesharedpreferences/MainActivity.java
@@ -1,9 +1,9 @@
 package at.favre.lib.securesharedpreferences;
 
 import android.content.Intent;
-import android.databinding.DataBindingUtil;
+import androidx.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 
 import at.favre.lib.armadillo.Armadillo;

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -3,12 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="at.favre.lib.securesharedpreferences.ChangePasswordActivity">
 
-        <android.support.design.widget.TextInputLayout
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/current_password_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -29,9 +29,9 @@
                 android:inputType="textPassword"
                 android:maxLines="1" />
 
-        </android.support.design.widget.TextInputLayout>
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <android.support.design.widget.TextInputLayout
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/new_password_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -52,7 +52,7 @@
                 android:inputType="textPassword"
                 android:maxLines="1" />
 
-        </android.support.design.widget.TextInputLayout>
+        </com.google.android.material.textfield.TextInputLayout>
 
         <Button
             android:id="@+id/change_password_btn"
@@ -68,5 +68,5 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/new_password_layout" />
 
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="at.favre.lib.securesharedpreferences.MainActivity">
@@ -34,7 +34,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/logo" />
 
-        <android.support.design.widget.TextInputLayout
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/password_layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -55,7 +55,7 @@
                 android:inputType="textPassword"
                 android:maxLines="1" />
 
-        </android.support.design.widget.TextInputLayout>
+        </com.google.android.material.textfield.TextInputLayout>
 
         <Button
             android:id="@+id/btn_init"
@@ -69,7 +69,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/password_layout" />
 
-        <android.support.v7.widget.CardView
+        <androidx.cardview.widget.CardView
             android:id="@+id/card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -82,11 +82,11 @@
             app:layout_constraintTop_toBottomOf="@+id/password_layout"
             card_view:cardCornerRadius="4dp">
 
-            <android.support.constraint.ConstraintLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-                <android.support.design.widget.TextInputLayout
+                <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/key_layout"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -107,7 +107,7 @@
                         android:inputType="text"
                         android:maxLines="1" />
 
-                </android.support.design.widget.TextInputLayout>
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <Button
                     android:id="@+id/btn_get"
@@ -122,7 +122,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/key_layout" />
 
-                <android.support.design.widget.TextInputLayout
+                <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/value_layout"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -145,7 +145,7 @@
                         android:inputType="text"
                         android:maxLines="1" />
 
-                </android.support.design.widget.TextInputLayout>
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <Button
                     android:id="@+id/btn_set"
@@ -160,8 +160,8 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/value_layout" />
 
-            </android.support.constraint.ConstraintLayout>
-        </android.support.v7.widget.CardView>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
 
         <Button
             android:id="@+id/btn_close_preferences"
@@ -193,5 +193,5 @@
             app:layout_constraintStart_toEndOf="@+id/btn_close_preferences"
             app:layout_constraintTop_toBottomOf="@+id/card" />
 
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -5,16 +5,23 @@ apply from: "$rootDir/gradle/jacoco-utils.gradle"
 apply from: "$rootDir/gradle/checkstyle.gradle"
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    compileOptions {
+        encoding "UTF-8"
+        sourceCompatibility androidConfig.javaVersion
+        targetCompatibility androidConfig.javaVersion
+    }
+
+    compileSdkVersion androidConfig.compileSdkVersion
+    buildToolsVersion androidConfig.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.versionCode
-        versionName rootProject.ext.versionNameLib
+        minSdkVersion androidConfig.minSdkVersion
+        targetSdkVersion androidConfig.targetSdkVersion
+        versionCode versionCode
+        versionName versionNameLib
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner androidConfig.testInstrumentationRunner
 
         buildConfigField "byte[]", "PREF_SALT", "new byte[]{0x4F, 0x00, 0x10, 0x2E, 0x62, 0x45, 0x4C, 0x0F, 0x3B, (byte) 0xF9, 0x37, 0x50, 0x47, 0x22, 0x24, 0x5D, (byte) 0xE0, (byte) 0xD8, 0x55, (byte) 0xC1, (byte) 0xBA, 0x23, (byte) 0x8D, (byte) 0xA9, (byte) 0xF0, (byte) 0xA3, 0x77, 0x4D, 0x38, 0x61, (byte) 0xF0, (byte) 0xBB};"
         buildConfigField "byte[]", "STATIC_RANDOM", "new byte[]{(byte) 0xBC, 0x1D, (byte) 0x91, 0x7B, (byte) 0xB3, (byte) 0xD7, (byte) 0xA4, 0x19, 0x2C, 0x72, 0x52, (byte) 0xF4, 0x34, (byte) 0xDC, (byte) 0xCC, 0x4F, (byte) 0xDC, (byte) 0xD8, (byte) 0xEF, 0x51, (byte) 0xF0, (byte) 0xA9, 0x5B, (byte) 0xDD, 0x62, 0x1A, 0x53, 0x10, (byte) 0xDD, 0x21, (byte) 0x83, (byte) 0xBD};"
@@ -36,33 +43,26 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        encoding "UTF-8"
-        sourceCompatibility rootProject.ext.javaVersion
-        targetCompatibility rootProject.ext.javaVersion
-    }
+
     testOptions {
         unitTests.returnDefaultValues = true
     }
 }
 
 dependencies {
-    api 'at.favre.lib:hkdf:1.0.0'
-    api 'at.favre.lib:bytes:0.8.0'
-    api 'at.favre.lib:bcrypt:0.6.0'
-    api 'com.jakewharton.timber:timber:4.7.1'
+    api libDependencies.hkdf
+    api libDependencies.bytesUtils
+    api libDependencies.bcrypt
+    api libDependencies.timber
+    api libDependencies.annotation
 
-    api group: 'com.android.support', name: 'support-annotations', version: rootProject.ext.dependencies.support
+    testImplementation testDependencies.junit
+    testImplementation testDependencies.jBCrypt
 
-    testImplementation 'org.mindrot:jbcrypt:0.4'
-    testImplementation "junit:junit:$rootProject.ext.dependencies.junit"
-
-    androidTestImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
-    androidTestImplementation 'org.mindrot:jbcrypt:0.4'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation(group: 'com.android.support.test.espresso', name: 'espresso-core', version: rootProject.ext.dependencies.espresso, {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    androidTestImplementation testDependencies.testRunner
+    androidTestImplementation testDependencies.espresso
+    androidTestImplementation testDependencies.jBCrypt
+    androidTestImplementation testDependencies.bouncyCastle
 }
 
 apply from: "$rootDir/gradle/publish.gradle"

--- a/armadillo/src/androidTest/java/at/favre/lib/armadillo/SecureSharedPreferencesTest.java
+++ b/armadillo/src/androidTest/java/at/favre/lib/armadillo/SecureSharedPreferencesTest.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/AesCbcEncryption.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/AesCbcEncryption.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/AesGcmEncryption.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/AesGcmEncryption.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 import java.security.Provider;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/Armadillo.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/Armadillo.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.security.Provider;
 import java.security.SecureRandom;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
 import android.content.SharedPreferences;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Extending the {@link SharedPreferences} interface this exports additional APIs specific

--- a/armadillo/src/main/java/at/favre/lib/armadillo/AuthenticatedEncryption.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/AuthenticatedEncryption.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.IntDef;
-import android.support.annotation.Nullable;
+import androidx.annotation.IntDef;
+import androidx.annotation.Nullable;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/DataObfuscator.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/DataObfuscator.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Data obfuscation which obfuscates the given byte arrays.

--- a/armadillo/src/main/java/at/favre/lib/armadillo/DefaultEncryptionProtocol.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/DefaultEncryptionProtocol.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/DerivedPasswordCache.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/DerivedPasswordCache.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.LruCache;
 
 import java.security.SecureRandom;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/EncryptionFingerprintFactory.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/EncryptionFingerprintFactory.java
@@ -7,7 +7,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.Signature;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 

--- a/armadillo/src/main/java/at/favre/lib/armadillo/EncryptionProtocol.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/EncryptionProtocol.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.security.SecureRandom;
 

--- a/armadillo/src/main/java/at/favre/lib/armadillo/HkdfXorObfuscator.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/HkdfXorObfuscator.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/KeyStretchingFunction.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/KeyStretchingFunction.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * In cryptography, key stretching techniques are used to make a possibly weak key, typically a password or

--- a/armadillo/src/main/java/at/favre/lib/armadillo/NoObfuscator.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/NoObfuscator.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * A simple No-Op implementation for {@link DataObfuscator}. Use this for testing purpose.

--- a/armadillo/src/main/java/at/favre/lib/armadillo/PBKDF2KeyStretcher.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/PBKDF2KeyStretcher.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
 import android.os.StrictMode;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/RecoveryPolicy.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/RecoveryPolicy.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Defines how the storage should behave on errors while decrypting.

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SecureSharedPreferences.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SecureSharedPreferences.java
@@ -4,8 +4,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.StrictMode;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.security.SecureRandom;
 import java.util.Arrays;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SimpleRecoveryPolicy.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SimpleRecoveryPolicy.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Simple implementation of a {@link RecoveryPolicy} that supports removing data

--- a/armadillo/src/test/java/at/favre/lib/armadillo/BrokenBcryptKeyStretcherTest.java
+++ b/armadillo/src/test/java/at/favre/lib/armadillo/BrokenBcryptKeyStretcherTest.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
 import android.os.StrictMode;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;

--- a/armadillo/src/test/java/at/favre/lib/armadillo/DefaultEncryptionProtocolTest.java
+++ b/armadillo/src/test/java/at/favre/lib/armadillo/DefaultEncryptionProtocolTest.java
@@ -1,6 +1,6 @@
 package at.favre.lib.armadillo;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.junit.Test;
 

--- a/armadillo/src/test/java/at/favre/lib/armadillo/MockSharedPref.java
+++ b/armadillo/src/test/java/at/favre/lib/armadillo/MockSharedPref.java
@@ -1,7 +1,7 @@
 package at.favre.lib.armadillo;
 
 import android.content.SharedPreferences;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,17 @@
 apply from: "$rootDir/gradle/common-build.gradle"
 
 buildscript {
-
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        apply from: 'dependencies.gradle'
+        classpath gradleDependencies.gradleAndroid
+        classpath gradleDependencies.gradleAndroidMaven
+        classpath gradleDependencies.gradleBintray
+        classpath gradleDependencies.gradleCoverrals
+        classpath gradleDependencies.gradleJacoco
     }
 }
 
@@ -30,23 +27,16 @@ task clean(type: Delete) {
 }
 
 ext {
-
     versionNameLib = "0.7.0"
     versionNameApp = "v$versionNameLib"
     versionCode = getCiBuildNumber()
 
-    compileSdkVersion = 28
-    buildToolsVersion = "28.0.3"
-    targetSdkVersion = 28
-
-    minSdkVersion = 19
-    javaVersion = JavaVersion.VERSION_1_8
-
-    dependencies = [
-            support         : "28.0.0",
-            constraintLayout: "1.1.2",
-            espresso        : "3.0.2",
-            junit           : "4.12",
-            stetho          : "1.5.0"
+    androidConfig = [
+            buildToolsVersion        : "28.0.3", // https://developer.android.com/studio/releases/build-tools
+            minSdkVersion            : 19,
+            targetSdkVersion         : 28,
+            compileSdkVersion        : 28,
+            testInstrumentationRunner: "androidx.test.runner.AndroidJUnitRunner",
+            javaVersion              : JavaVersion.VERSION_1_8
     ]
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,94 @@
+ext {
+
+    //----------------------------------------------------------------------------------------------
+    // Gradle Dependencies
+    //----------------------------------------------------------------------------------------------
+
+    // Gradle Android Plugin : https://developer.android.com/studio/releases/gradle-plugin.html#updating-plugin
+    gradleAndroid = '3.4.0-alpha08'
+    // Gradle Android Maven Plugin : https://github.com/dcendents/android-maven-gradle-plugin
+    gradleAndroidMaven = '2.1'
+    // Gradle Bintray Plugin : https://github.com/bintray/gradle-bintray-plugin
+    gradleBintray = '1.8.4'
+    // Gradle Coveralls Plugin : https://github.com/kt3k/coveralls-gradle-plugin
+    gradleCoverrals = '2.8.2'
+    // Gradle JaCoCo Plugin : https://github.com/arturdm/jacoco-android-gradle-plugin
+    gradleJacoco = '0.1.3'
+
+    gradleDependencies = [
+            gradleAndroid     : "com.android.tools.build:gradle:${gradleAndroid}",
+            gradleAndroidMaven: "com.github.dcendents:android-maven-gradle-plugin:${gradleAndroidMaven}",
+            gradleBintray     : "com.jfrog.bintray.gradle:gradle-bintray-plugin:${gradleBintray}",
+            gradleCoverrals   : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${gradleCoverrals}",
+            gradleJacoco      : "com.dicedmelon.gradle:jacoco-android:${gradleJacoco}",
+    ]
+
+    //----------------------------------------------------------------------------------------------
+    // Lib Dependencies
+    //----------------------------------------------------------------------------------------------
+
+    // HKDF : https://github.com/patrickfav/hkdf
+    hkdf = '1.0.0'
+    // Bytes Utility Library : https://github.com/patrickfav/bytes-java
+    bytesUtils = '0.8.0'
+    // Bcrypt : https://github.com/patrickfav/bcrypt
+    bcrypt = '0.5.0'
+    // Timber : https://github.com/JakeWharton/timber
+    timber = '4.7.1'
+    // Android annotations : https://mvnrepository.com/artifact/androidx.annotation/annotation?repo=google
+    annotation = '1.0.0'
+
+    libDependencies = [
+            hkdf      : "at.favre.lib:hkdf:${hkdf}",
+            bytesUtils: "at.favre.lib:bytes:${bytesUtils}",
+            bcrypt    : "at.favre.lib:bcrypt:${bcrypt}",
+            timber    : "com.jakewharton.timber:timber:${timber}",
+            annotation: "androidx.annotation:annotation:${annotation}",
+    ]
+
+    //----------------------------------------------------------------------------------------------
+    // App Dependencies
+    //----------------------------------------------------------------------------------------------
+
+    // AppCompat : https://mvnrepository.com/artifact/androidx.appcompat/appcompat?repo=google
+    appCompat = '1.0.0'
+    // Constraint Layout : https://mvnrepository.com/artifact/androidx.constraintlayout/constraintlayout?repo=google
+    constraintLayout = '1.1.3'
+    // CardView : https://mvnrepository.com/artifact/androidx.cardview/cardview?repo=google
+    cardView = '1.0.0'
+    // Material Components : https://mvnrepository.com/artifact/com.google.android.material/material?repo=google
+    materialComponents = '1.0.0'
+    // Stetho : https://github.com/facebook/stetho
+    stetho = '1.5.0'
+
+    appDependencies = [
+            appCompat         : "androidx.appcompat:appcompat:${appCompat}",
+            constraintLayout  : "androidx.constraintlayout:constraintlayout:${constraintLayout}",
+            cardView          : "androidx.cardview:cardview:${cardView}",
+            materialComponents: "com.google.android.material:material:${materialComponents}",
+            stetho            : "com.facebook.stetho:stetho:${stetho}",
+    ]
+
+    //----------------------------------------------------------------------------------------------
+    // Test Dependencies
+    //----------------------------------------------------------------------------------------------
+
+    // JUnit (unit testing framework) : http://junit.org/junit4/
+    junit = '4.12'
+    // Test Runner : https://mvnrepository.com/artifact/androidx.test/runner?repo=google
+    testRunner = '1.1.0'
+    // Espresso : https://mvnrepository.com/artifact/androidx.test.espresso/espresso-core?repo=google
+    espresso = '3.1.0'
+    // jBCrypt : https://github.com/jeremyh/jBCrypt
+    jBCrypt = '0.4'
+    // Bouncy Castle : https://www.bouncycastle.org/latest_releases.html
+    bouncyCastle = '1.60'
+
+    testDependencies = [
+            junit       : "junit:junit:${junit}",
+            testRunner  : "androidx.test:runner:${testRunner}",
+            espresso    : "androidx.test.espresso:espresso-core:${espresso}",
+            jBCrypt     : "org.mindrot:jbcrypt:${jBCrypt}",
+            bouncyCastle: "org.bouncycastle:bcprov-jdk15on:${bouncyCastle}",
+    ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,9 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# AndroidX
+android.enableJetifier=true
+android.useAndroidX=true
+# Don't run Jetifier in signed libs
+android.jetifier.blacklist=hkdf,bcrypt,bytes

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 18 20:34:35 CET 2017
+#Sat Dec 22 11:29:36 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-milestone-1-all.zip


### PR DESCRIPTION
I was trying to migrate the library to AndroidX, but I'm having problems with the bcrypt library.

When I try to compile I get:
```
SecurityException: SHA-256 digest error for at/favre/lib/crypto/bcrypt/BCryptFormatter.class
```

My guess is that Jetifier is trying to modify the bcrypt library jar (although I don't know why, because it doesn't have any android support dependency). But the library is signed with your private key, so then the signature validation fails.

@patrickfav do you have any clue how can we solve the issue?

