### PR TITLE
Feat/enhanced change listener

### DIFF
--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     androidTestImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     androidTestImplementation 'org.mindrot:jbcrypt:0.4'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation(group: 'com.android.support.test.espresso', name: 'espresso-core', version: rootProject.ext.dependencies.espresso, {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/armadillo/src/androidTest/java/at/favre/lib/armadillo/SecureSharedPreferencesTest.java
+++ b/armadillo/src/androidTest/java/at/favre/lib/armadillo/SecureSharedPreferencesTest.java
@@ -6,7 +6,6 @@ import android.os.Build;
 import android.provider.Settings;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.annotation.UiThreadTest;
-import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Test;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
@@ -1,6 +1,7 @@
 package at.favre.lib.armadillo;
 
 import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
@@ -46,6 +47,47 @@ public interface ArmadilloSharedPreferences extends SharedPreferences {
      *                    ignored if null is passed.
      */
     void changePassword(@Nullable char[] newPassword, @Nullable KeyStretchingFunction function);
+
+    /**
+     * Registers to listen changes on the underlying preferences in a secure fashion, as the regular
+     * {@link SharedPreferences#registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener)}
+     * is useless as it returns <em>derivedContentKey</em> as parameter, and we cannot compare it to noting
+     * in case we're interested in some specific key change.
+     *
+     * <pre>
+     *     public class SampleActivity extends AppCompatActivity {
+     *         private final String KEY_TOKEN = "token";
+     *         private final OnSecurePreferenceChangeListener onSecurePreferenceChangeListener = (sharedPreferences, comparison) -> {
+     *             if (comparison.isDerivedKeyEqualTo(KEY_TOKEN)) {
+     *
+     *                 String newToken = sharedPreferences.getString(KEY_TOKEN, null);
+     *                 onTokenUpdated(newToken);
+     *             }
+     *         };
+     *
+     *         private void onTokenUpdated(String newToken) {
+     *             // Do whatever is required when underlying token has been updated
+     *         }
+     *
+     *         &#64;Override
+     *         protected void onCreate(Bundle savedInstanceState) {
+     *             super.onCreate(savedInstanceState);
+     *             // ... initialize encrypted preferences ...
+     *             encryptedPreferences.registerOnSecurePreferenceChangeListener(onSecurePreferenceChangeListener);
+     *         }
+     *    }
+     * </pre>
+     *
+     * @param listener were change notifications will be delivered. You need to keep <b>strong</b> reference to it to avoid garbage collection. Same behaviour as the platform
+     *                 {@linkplain SharedPreferences}
+     */
+    void registerOnSecurePreferenceChangeListener(@NonNull OnSecurePreferenceChangeListener listener);
+
+    /**
+     * Unregisters previously registered {@link OnSecurePreferenceChangeListener} from preference update.
+     * @param listener is an already registered instance that will be unregistered then, will stop receiving updates.
+     */
+    void unregisterOnSecurePreferenceChangeListener(@NonNull OnSecurePreferenceChangeListener listener);
 
     /**
      * Changes the user provided password to the new given password. This will immediately reencrypt

--- a/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
@@ -53,6 +53,10 @@ public interface ArmadilloSharedPreferences extends SharedPreferences {
      * {@link SharedPreferences#registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener)}
      * is useless as it returns <em>derivedContentKey</em> as parameter, and we cannot compare it to noting
      * in case we're interested in some specific key change.
+     * <br/><br/>
+     * Thus we change it to provide an alternative method using {@link OnSecurePreferenceChangeListener}. You can
+     * find an example of usage below.
+     * <br/><br/>
      *
      * <pre>
      *     public class SampleActivity extends AppCompatActivity {

--- a/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/ArmadilloSharedPreferences.java
@@ -82,8 +82,7 @@ public interface ArmadilloSharedPreferences extends SharedPreferences {
      *    }
      * </pre>
      *
-     * @param listener were change notifications will be delivered. You need to keep <b>strong</b> reference to it to avoid garbage collection. Same behaviour as the platform
-     *                 {@linkplain SharedPreferences}
+     * @param listener were change notifications will be delivered.
      */
     void registerOnSecurePreferenceChangeListener(@NonNull OnSecurePreferenceChangeListener listener);
 

--- a/armadillo/src/main/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListener.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListener.java
@@ -4,19 +4,44 @@ import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 
 /**
- * Allow to register preference change listeners that receive
- * @since 03.07.2019
+ * Allow to register preference change listeners that receive a {@link DerivedKeyComparison} instance in order to make it possible compare the changed key against
+ * actual key constants.
+ *
+ * <pre>
+ *     public class SampleActivity extends AppCompatActivity {
+ *         private final String KEY_TOKEN = "token";
+ *         private final OnSecurePreferenceChangeListener onSecurePreferenceChangeListener = (sharedPreferences, comparison) -> {
+ *             if (comparison.isDerivedKeyEqualTo(KEY_TOKEN)) {
+ *
+ *                 String newToken = sharedPreferences.getString(KEY_TOKEN, null);
+ *                 onTokenUpdated(newToken);
+ *             }
+ *         };
+ *
+ *         private void onTokenUpdated(String newToken) {
+ *             // Do whatever is required when underlying token has been updated
+ *         }
+ *
+ *         &#64;Overrides
+ *         protected void onCreate(Bundle savedInstanceState) {
+ *             super.onCreate(savedInstanceState);
+ *             // ... initialize encrypted preferences ...
+ *             encryptedPreferences.registerOnSecurePreferenceChangeListener(onSecurePreferenceChangeListener);
+ *         }
+ *    }
+ * </pre>
+ *
+ * @since 0.9.0
  */
 public interface OnSecurePreferenceChangeListener {
 
     /**
      * Variation of the regular {@link android.content.SharedPreferences.OnSharedPreferenceChangeListener#onSharedPreferenceChanged(SharedPreferences, String)} that
      * provides a {@link DerivedKeyComparison} to allow client side react only to a specific changed key
-     * @param comparison utility to check equivalence between plain keys and derived keys
      * @param sharedPreferences the shared preferences instance
-     * @param derivedKeyChanged the value of the changed key in it's derived form (as it's actually stored)
+     * @param comparison utility to check equivalence between plain keys and derived keys
      */
-    void onSecurePreferenceChanged(@NonNull DerivedKeyComparison comparison, @NonNull SharedPreferences sharedPreferences, @NonNull String derivedKeyChanged);
+    void onSecurePreferenceChanged(@NonNull SharedPreferences sharedPreferences, @NonNull DerivedKeyComparison comparison);
 
     /**
      * Allows client side {@link OnSecurePreferenceChangeListener} to check if the changed key is the key of interest.
@@ -24,11 +49,10 @@ public interface OnSecurePreferenceChangeListener {
     interface DerivedKeyComparison {
 
         /**
-         * Checks if the given derivedKey and key are equivalent.
-         * @param derivedKey is derived key returned on method
-         * @param key is the plain key to check equality against derivedKey
-         * @return
+         * Checks if the given key is equal to the derivedContentKey that changed which is undisclosed.
+         * @param key is the plain key to check equality against derivedContentKey
+         * @return true if given key is equal to the contained <em>derivedContentKey</em>
          */
-        boolean isDerivedKeyEqualTo(@NonNull String derivedKey, @NonNull String key);
+        boolean isDerivedKeyEqualTo(@NonNull String key);
     }
 }

--- a/armadillo/src/main/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListener.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListener.java
@@ -1,0 +1,34 @@
+package at.favre.lib.armadillo;
+
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+
+/**
+ * Allow to register preference change listeners that receive
+ * @since 03.07.2019
+ */
+public interface OnSecurePreferenceChangeListener {
+
+    /**
+     * Variation of the regular {@link android.content.SharedPreferences.OnSharedPreferenceChangeListener#onSharedPreferenceChanged(SharedPreferences, String)} that
+     * provides a {@link DerivedKeyComparison} to allow client side react only to a specific changed key
+     * @param comparison utility to check equivalence between plain keys and derived keys
+     * @param sharedPreferences the shared preferences instance
+     * @param derivedKeyChanged the value of the changed key in it's derived form (as it's actually stored)
+     */
+    void onSecurePreferenceChanged(@NonNull DerivedKeyComparison comparison, @NonNull SharedPreferences sharedPreferences, @NonNull String derivedKeyChanged);
+
+    /**
+     * Allows client side {@link OnSecurePreferenceChangeListener} to check if the changed key is the key of interest.
+     */
+    interface DerivedKeyComparison {
+
+        /**
+         * Checks if the given derivedKey and key are equivalent.
+         * @param derivedKey is derived key returned on method
+         * @param key is the plain key to check equality against derivedKey
+         * @return
+         */
+        boolean isDerivedKeyEqualTo(@NonNull String derivedKey, @NonNull String key);
+    }
+}

--- a/armadillo/src/main/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListener.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListener.java
@@ -5,8 +5,9 @@ import android.support.annotation.NonNull;
 
 /**
  * Allow to register preference change listeners that receive a {@link DerivedKeyComparison} instance in order to make it possible compare the changed key against
- * actual key constants.
- *
+ * <b>actual</b> key constants (instead of the derivedKeys that the library uses)
+ * <br/><br/>
+ * <em>Example:</em>
  * <pre>
  *     public class SampleActivity extends AppCompatActivity {
  *         private final String KEY_TOKEN = "token";

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SecureSharedPreferences.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SecureSharedPreferences.java
@@ -258,29 +258,16 @@ public final class SecureSharedPreferences implements ArmadilloSharedPreferences
 
     private final List<SharedPreferenceChangeListenerWrapper> securePreferenceListeners = new LinkedList<>();
 
+    @Override
     public void registerOnSecurePreferenceChangeListener(@NonNull OnSecurePreferenceChangeListener listener) {
         synchronized (securePreferenceListeners) {
-            ListIterator<SharedPreferenceChangeListenerWrapper> iterator = securePreferenceListeners.listIterator();
-            boolean found = false;
-            while (iterator.hasNext()) {
-                SharedPreferenceChangeListenerWrapper listenerWrapper = iterator.next();
-                OnSecurePreferenceChangeListener wrapped = listenerWrapper.getWrapped();
-                if (wrapped == null) {
-                    unregisterOnSharedPreferenceChangeListener(listenerWrapper);
-                    iterator.remove();
-                } else if (wrapped == listener) {
-                    found = true; // we let the loop continue, so that we may cleanup some more references
-                }
-            }
-
-            if (!found) {
-                SharedPreferenceChangeListenerWrapper listenerWrapper = new SharedPreferenceChangeListenerWrapper(listener, encryptionProtocol);
-                registerOnSharedPreferenceChangeListener(listenerWrapper);
-                securePreferenceListeners.add(listenerWrapper);
-            }
+            SharedPreferenceChangeListenerWrapper listenerWrapper = new SharedPreferenceChangeListenerWrapper(listener, encryptionProtocol, this);
+            registerOnSharedPreferenceChangeListener(listenerWrapper);
+            securePreferenceListeners.add(listenerWrapper);
         }
     }
 
+    @Override
     public void unregisterOnSecurePreferenceChangeListener(@NonNull OnSecurePreferenceChangeListener listener) {
         synchronized (securePreferenceListeners) {
             ListIterator<SharedPreferenceChangeListenerWrapper> iterator = securePreferenceListeners.listIterator();

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
@@ -28,7 +28,7 @@ final class SharedPreferenceChangeListenerWrapper implements SharedPreferences.O
     }
 
     private final WeakReference<OnSecurePreferenceChangeListener> wrappedRef;
-    @NonNull private final EncryptionProtocol                     encryptionProtocol;
+    @NonNull private final EncryptionProtocol encryptionProtocol;
     @NonNull private final SharedPreferences securedPrefs;
 
     SharedPreferenceChangeListenerWrapper(@NonNull OnSecurePreferenceChangeListener wrapped, @NonNull EncryptionProtocol encryptionProtocol, @NonNull SharedPreferences securedPrefs) {

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
@@ -1,0 +1,56 @@
+package at.favre.lib.armadillo;
+
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Implementation that will wrap a {@link OnSecurePreferenceChangeListener} to adapt to the standard {@link SharedPreferences.OnSharedPreferenceChangeListener}
+ * @since 03.07.2019
+ */
+final class SharedPreferenceChangeListenerWrapper implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private static class KeyComparissonImpl implements OnSecurePreferenceChangeListener.DerivedKeyComparison  {
+        private final EncryptionProtocol encryptionProtocol;
+
+        private KeyComparissonImpl(EncryptionProtocol encryptionProtocol) {
+            this.encryptionProtocol = encryptionProtocol;
+        }
+
+        @Override
+        public boolean isDerivedKeyEqualTo(@NonNull String derivedKey, @NonNull String key) {
+            return derivedKey.equals(encryptionProtocol.deriveContentKey(key));
+        }
+    }
+
+    private final OnSecurePreferenceChangeListener.DerivedKeyComparison keyComparison;
+    private final WeakReference<OnSecurePreferenceChangeListener>       wrappedRef;
+
+    SharedPreferenceChangeListenerWrapper(@NonNull OnSecurePreferenceChangeListener wrapped, @NonNull EncryptionProtocol encryptionProtocol) {
+        keyComparison = new KeyComparissonImpl(encryptionProtocol);
+        wrappedRef = new WeakReference<>(wrapped);
+    }
+
+    @Nullable
+    OnSecurePreferenceChangeListener getWrapped() {
+        return wrappedRef.get();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+
+        OnSecurePreferenceChangeListener wrapped = wrappedRef.get();
+
+        if (wrapped == null && sharedPreferences != null) {
+            // we unregister ourselves from client preferences
+            sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
+            return;
+        }
+
+        if (sharedPreferences != null && key != null) {
+            wrapped.onSecurePreferenceChanged(keyComparison, sharedPreferences, key);
+        }
+    }
+}

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
@@ -2,9 +2,6 @@ package at.favre.lib.armadillo;
 
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
-import java.lang.ref.WeakReference;
 
 /**
  * Implementation that will wrap a {@link OnSecurePreferenceChangeListener} to adapt to the standard {@link SharedPreferences.OnSharedPreferenceChangeListener}
@@ -27,34 +24,25 @@ final class SharedPreferenceChangeListenerWrapper implements SharedPreferences.O
         }
     }
 
-    private final WeakReference<OnSecurePreferenceChangeListener> wrappedRef;
+    private final OnSecurePreferenceChangeListener wrappedListener;
     @NonNull private final EncryptionProtocol encryptionProtocol;
     @NonNull private final SharedPreferences securedPrefs;
 
     SharedPreferenceChangeListenerWrapper(@NonNull OnSecurePreferenceChangeListener wrapped, @NonNull EncryptionProtocol encryptionProtocol, @NonNull SharedPreferences securedPrefs) {
-        wrappedRef = new WeakReference<>(wrapped);
+        wrappedListener = wrapped;
         this.encryptionProtocol = encryptionProtocol;
         this.securedPrefs = securedPrefs;
     }
 
-    @Nullable
     OnSecurePreferenceChangeListener getWrapped() {
-        return wrappedRef.get();
+        return wrappedListener;
     }
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
 
-        OnSecurePreferenceChangeListener wrapped = wrappedRef.get();
-
-        if (wrapped == null) {
-            // we unregister ourselves from client preferences
-            sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
-            return;
-        }
-
         if (key != null) {
-            wrapped.onSecurePreferenceChanged(securedPrefs, new KeyComparisonImpl(encryptionProtocol, key));
+            wrappedListener.onSecurePreferenceChanged(securedPrefs, new KeyComparisonImpl(encryptionProtocol, key));
         }
     }
 }

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SharedPreferenceChangeListenerWrapper.java
@@ -12,7 +12,7 @@ import java.lang.ref.WeakReference;
  */
 final class SharedPreferenceChangeListenerWrapper implements SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private static class KeyComparissonImpl implements OnSecurePreferenceChangeListener.DerivedKeyComparison  {
+    private static class KeyComparissonImpl implements OnSecurePreferenceChangeListener.DerivedKeyComparison {
         private final EncryptionProtocol encryptionProtocol;
 
         private KeyComparissonImpl(EncryptionProtocol encryptionProtocol) {
@@ -26,7 +26,7 @@ final class SharedPreferenceChangeListenerWrapper implements SharedPreferences.O
     }
 
     private final OnSecurePreferenceChangeListener.DerivedKeyComparison keyComparison;
-    private final WeakReference<OnSecurePreferenceChangeListener>       wrappedRef;
+    private final WeakReference<OnSecurePreferenceChangeListener> wrappedRef;
 
     SharedPreferenceChangeListenerWrapper(@NonNull OnSecurePreferenceChangeListener wrapped, @NonNull EncryptionProtocol encryptionProtocol) {
         keyComparison = new KeyComparissonImpl(encryptionProtocol);

--- a/armadillo/src/test/java/at/favre/lib/armadillo/MockSharedPref.java
+++ b/armadillo/src/test/java/at/favre/lib/armadillo/MockSharedPref.java
@@ -2,6 +2,7 @@ package at.favre.lib.armadillo;
 
 import android.content.SharedPreferences;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -99,6 +100,11 @@ public class MockSharedPref implements SharedPreferences {
     @Override
     public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener onSharedPreferenceChangeListener) {
         listeners.remove(onSharedPreferenceChangeListener);
+    }
+
+    @VisibleForTesting
+    int getNumListeners() {
+        return listeners.size();
     }
 
     void executeTransaction(Map<String, Object> putMap, List<String> removeList, boolean clear) {

--- a/armadillo/src/test/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListenerTest.java
+++ b/armadillo/src/test/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListenerTest.java
@@ -69,7 +69,6 @@ public class OnSecurePreferenceChangeListenerTest {
         assertEquals(0, mockSharedPref.getNumListeners());
     }
 
-
     private static class TestSecurePreferenceChange implements OnSecurePreferenceChangeListener {
         private final String expectedKey;
         private String newValue;

--- a/armadillo/src/test/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListenerTest.java
+++ b/armadillo/src/test/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListenerTest.java
@@ -1,0 +1,98 @@
+package at.favre.lib.armadillo;
+
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import at.favre.lib.bytes.Bytes;
+
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * Tests for the {@link OnSecurePreferenceChangeListener}
+ */
+public class OnSecurePreferenceChangeListenerTest {
+
+    private ArmadilloSharedPreferences armadilloSharedPreferences;
+    private TestSecurePreferenceChange testSecurePreferenceChange = new TestSecurePreferenceChange("target-key");
+    private final MockSharedPref mockSharedPref = new MockSharedPref();
+
+    @Before
+    public void onSetup() {
+        armadilloSharedPreferences = Armadillo.create(mockSharedPref).encryptionFingerprint(Bytes.parseHex("6894964e2be3b5aaed5ca8c2724f4915").array())
+                                              .password("1234".toCharArray())
+                                              .build();
+
+        armadilloSharedPreferences.registerOnSecurePreferenceChangeListener(testSecurePreferenceChange);
+    }
+
+    @After
+    public void onCleanup() {
+        armadilloSharedPreferences.unregisterOnSecurePreferenceChangeListener(testSecurePreferenceChange);
+    }
+
+    @Test
+    public void testUpdatedKeyNotifiesProperly() {
+        armadilloSharedPreferences.edit().putString("target-key", "a new hope").apply();
+        assertEquals("a new hope", testSecurePreferenceChange.getNewValue());
+    }
+
+    @Test
+    public void testUpdateAnotherCanBeIgnored() {
+        armadilloSharedPreferences.edit().putString("different-key", "a new hope").apply();
+        assertEquals(0, testSecurePreferenceChange.getNumHits());
+    }
+
+    @Test
+    public void testImplementationRegistersListenerWithPlatformPreferences() {
+        assertEquals(1, mockSharedPref.getNumListeners());
+    }
+
+    @Test
+    public void testUnregisterAlsoUnregistersPlatform() {
+        armadilloSharedPreferences.unregisterOnSecurePreferenceChangeListener(testSecurePreferenceChange);
+        assertEquals(0, mockSharedPref.getNumListeners());
+    }
+
+    @Test
+    public void testGarbageCollectionAlsoUnregistersFromListener() {
+        armadilloSharedPreferences.unregisterOnSecurePreferenceChangeListener(testSecurePreferenceChange);
+        armadilloSharedPreferences.registerOnSecurePreferenceChangeListener(new TestSecurePreferenceChange("target-key"));
+
+        System.gc();
+
+        // Unregistration happens on the first event of notification
+        armadilloSharedPreferences.edit().putString("target-key", "a new hope").apply();
+        assertEquals(0, mockSharedPref.getNumListeners());
+    }
+
+
+    private static class TestSecurePreferenceChange implements OnSecurePreferenceChangeListener {
+        private final String expectedKey;
+        private String newValue;
+        private int numHits = 0;
+
+        private TestSecurePreferenceChange(String expectedKey) {
+            this.expectedKey = expectedKey;
+        }
+
+        @Override
+        public void onSecurePreferenceChanged(@NonNull SharedPreferences sharedPreferences, @NonNull DerivedKeyComparison comparison) {
+            if (comparison.isDerivedKeyEqualTo(expectedKey)) {
+                newValue = sharedPreferences.getString(expectedKey, null);
+                numHits++;
+            }
+        }
+
+        String getNewValue() {
+            return newValue;
+        }
+
+        int getNumHits() {
+            return numHits;
+        }
+    }
+}

--- a/armadillo/src/test/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListenerTest.java
+++ b/armadillo/src/test/java/at/favre/lib/armadillo/OnSecurePreferenceChangeListenerTest.java
@@ -57,18 +57,6 @@ public class OnSecurePreferenceChangeListenerTest {
         assertEquals(0, mockSharedPref.getNumListeners());
     }
 
-    @Test
-    public void testGarbageCollectionAlsoUnregistersFromListener() {
-        armadilloSharedPreferences.unregisterOnSecurePreferenceChangeListener(testSecurePreferenceChange);
-        armadilloSharedPreferences.registerOnSecurePreferenceChangeListener(new TestSecurePreferenceChange("target-key"));
-
-        System.gc();
-
-        // Unregistration happens on the first event of notification
-        armadilloSharedPreferences.edit().putString("target-key", "a new hope").apply();
-        assertEquals(0, mockSharedPref.getNumListeners());
-    }
-
     private static class TestSecurePreferenceChange implements OnSecurePreferenceChangeListener {
         private final String expectedKey;
         private String newValue;


### PR DESCRIPTION
As EncryptionProtocol is not accessible and there may be the requirement to respond only to specific keys changed, and the regular `SharedPreferences.OnPreferenceChangeListener` callback isn't enough as we get the stored version of the key, witch we cannot compare against constants.

I've created a specific `OnSecurePreferenceChangeListener` that gives a facility  to at least compare the changed key against some arbitrary string.

I don't know in terms of security of implementation if this is the best way to achieve this. Please let me know if you think of another way more secure