### PR TITLE
Remove Timber and allow for more custom logging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,4 +35,5 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "com.facebook.stetho:stetho:$rootProject.ext.dependencies.stetho"
+    implementation 'com.jakewharton.timber:timber:4.7.1'
 }

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     api 'at.favre.lib:hkdf:1.1.0'
     api 'at.favre.lib:bytes:1.3.0'
     api 'at.favre.lib:bcrypt:0.9.0'
-    api 'com.jakewharton.timber:timber:4.7.1'
 
     api group: 'androidx.annotation', name: 'annotation', version: rootProject.ext.dependencies.support
 

--- a/armadillo/src/main/java/at/favre/lib/armadillo/Armadillo.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/Armadillo.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.provider.Settings;
+import android.util.Log;
+
 import androidx.annotation.Nullable;
 
 import java.security.Provider;
@@ -27,6 +29,7 @@ public final class Armadillo {
     public static final int CONTENT_KEY_OUT_BYTE_LENGTH = 20;
     public static final int DEFAULT_PROTOCOL_VERSION = 0;
     public static final int KITKAT_PROTOCOL_VERSION = -19;
+    static Logger logger = new DefaultLogger();
 
     private Armadillo() {
     }
@@ -61,6 +64,23 @@ public final class Armadillo {
      */
     public static Builder create(Context context, String preferenceName) {
         return new Builder(context, preferenceName);
+    }
+
+    /**
+     * Logs by default are sent to {@link Log}. Passing null as a here will turn off logging.
+     *
+     * @param logger A {@link Logger}
+     */
+    public static void setLogger(@Nullable final Logger logger) {
+        if (logger == null) {
+            Armadillo.logger = new NoOpLogger();
+        } else {
+            Armadillo.logger = logger;
+        }
+    }
+
+    static void log(int logLevel, String tag, String message, Object... args) {
+        Armadillo.logger.log(logLevel, tag, message, args)
     }
 
     /**
@@ -583,6 +603,26 @@ public final class Armadillo {
                 throw new UnsupportedOperationException("aes gcm is not supported with KitKat, add support " +
                         "manually with Armadillo.Builder.enableKitKatSupport()");
             }
+        }
+    }
+
+    public interface Logger {
+        void log(int logLevel, String tag, String message, Object... args);
+    }
+
+    private static class DefaultLogger implements Logger {
+
+        @Override
+        public void log(int logLevel, String tag, String message, Object... args) {
+            final String logMessage = String.format(message, args);
+            Log.println(logLevel, tag, logMessage);
+        }
+    }
+
+    private static class NoOpLogger implements Logger {
+        @Override
+        public void log(int logLevel, String tag, String message, Object... args) {
+            // do nothing.
         }
     }
 }

--- a/armadillo/src/main/java/at/favre/lib/armadillo/DefaultEncryptionProtocol.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/DefaultEncryptionProtocol.java
@@ -1,5 +1,7 @@
 package at.favre.lib.armadillo;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -13,7 +15,8 @@ import java.util.Objects;
 
 import at.favre.lib.bytes.Bytes;
 import at.favre.lib.crypto.HKDF;
-import timber.log.Timber;
+
+import static at.favre.lib.armadillo.Armadillo.log;
 
 /**
  * The Armadillo Encryption Protocol. The whole protocol logic, orchestrating all the other parts.
@@ -33,6 +36,7 @@ import timber.log.Timber;
  */
 
 final class DefaultEncryptionProtocol implements EncryptionProtocol {
+    private static final String TAG = DefaultEncryptionProtocol.class.getSimpleName();
 
     private static final int CONTENT_SALT_LENGTH_BYTES = 16;
     private static final int STRETCHED_PASSWORD_LENGTH_BYTES = 32;
@@ -101,7 +105,7 @@ final class DefaultEncryptionProtocol implements EncryptionProtocol {
         } finally {
             Bytes.wrap(fingerprintBytes).mutable().secureWipe();
             Bytes.wrap(key).mutable().secureWipe();
-            Timber.v("encrypt took %d ms", System.currentTimeMillis() - start);
+            log(Log.VERBOSE, TAG, "encrypt took %d ms", System.currentTimeMillis() - start);
         }
     }
 
@@ -155,7 +159,7 @@ final class DefaultEncryptionProtocol implements EncryptionProtocol {
         } finally {
             Bytes.wrap(fingerprintBytes).mutable().secureWipe();
             Bytes.wrap(key).mutable().secureWipe();
-            Timber.v("decrypt took %d ms", System.currentTimeMillis() - start);
+            log(Log.VERBOSE, TAG, "decrypt took %d ms", System.currentTimeMillis() - start);
         }
     }
 

--- a/armadillo/src/main/java/at/favre/lib/armadillo/EncryptionFingerprintFactory.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/EncryptionFingerprintFactory.java
@@ -7,12 +7,15 @@ import android.content.pm.PackageManager;
 import android.content.pm.Signature;
 import android.os.Build;
 import android.provider.Settings;
+import android.util.Log;
+
 import androidx.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 
 import at.favre.lib.bytes.Bytes;
-import timber.log.Timber;
+
+import static at.favre.lib.armadillo.Armadillo.log;
 
 /**
  * Factory for creating {@link EncryptionFingerprintFactory} in Android
@@ -22,6 +25,7 @@ import timber.log.Timber;
  */
 
 public final class EncryptionFingerprintFactory {
+    private static final String TAG = EncryptionFingerprintFactory.class.getSimpleName();
 
     private EncryptionFingerprintFactory() {
     }
@@ -86,7 +90,7 @@ public final class EncryptionFingerprintFactory {
     private static String getAndroidId(Context context) {
         String androidId = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
         if (androidId == null) { // fallback on devices that incorrectly return null
-            Timber.w("This devices returned null as ANDROID_ID, using fallback. This is not expected and may be a device bug. If this behaviour is non-deterministic, it may disrupt the possibility of decrypting the content.");
+            log(Log.WARN, TAG, "This devices returned null as ANDROID_ID, using fallback. This is not expected and may be a device bug. If this behaviour is non-deterministic, it may disrupt the possibility of decrypting the content.");
             return BuildConfig.ANDROID_ID_FALLBACK;
         }
         return androidId;

--- a/armadillo/src/main/java/at/favre/lib/armadillo/GzipCompressor.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/GzipCompressor.java
@@ -1,11 +1,13 @@
 package at.favre.lib.armadillo;
 
+import android.util.Log;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import timber.log.Timber;
+import static at.favre.lib.armadillo.Armadillo.log;
 
 /**
  * A compressor using Gzip algorithm provided by the JDK
@@ -14,6 +16,7 @@ import timber.log.Timber;
  * @since 06.01.2018
  */
 public final class GzipCompressor implements Compressor {
+    private static final String TAG = GzipCompressor.class.getSimpleName();
 
     public GzipCompressor() {
     }
@@ -32,7 +35,7 @@ public final class GzipCompressor implements Compressor {
             gzipInputStream.close();
             returnBuffer = bos.toByteArray();
             bos.close();
-            Timber.v("compression saved %d byte", compressed.length - returnBuffer.length);
+            log(Log.VERBOSE, TAG, "compression saved %d byte", compressed.length - returnBuffer.length);
             return returnBuffer;
         } catch (Exception e) {
             throw new IllegalStateException("could not decompress gzip", e);

--- a/armadillo/src/main/java/at/favre/lib/armadillo/SecureSharedPreferences.java
+++ b/armadillo/src/main/java/at/favre/lib/armadillo/SecureSharedPreferences.java
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.StrictMode;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -18,7 +20,8 @@ import java.util.Map;
 import java.util.Set;
 
 import at.favre.lib.bytes.Bytes;
-import timber.log.Timber;
+
+import static at.favre.lib.armadillo.Armadillo.log;
 
 /**
  * A simple wrapper implementation using the {@link DefaultEncryptionProtocol} before persisting
@@ -34,6 +37,7 @@ import timber.log.Timber;
  */
 @SuppressWarnings( {"unused", "WeakerAccess", "UnusedReturnValue"})
 public final class SecureSharedPreferences implements ArmadilloSharedPreferences {
+    private static final String TAG = SecureSharedPreferences.class.getSimpleName();
 
     private static final String PREFERENCES_SALT_KEY = "at.favre.lib.securepref.KEY_RANDOM";
     private static final String PASSWORD_VALIDATION_KEY = "at.favre.lib.securepref.PASSWORD_VALIDATION_KEY";
@@ -62,7 +66,7 @@ public final class SecureSharedPreferences implements ArmadilloSharedPreferences
 
     public SecureSharedPreferences(SharedPreferences sharedPreferences, EncryptionProtocol.Factory encryptionProtocolFactory,
                                    RecoveryPolicy recoveryPolicy, @Nullable char[] password, boolean supportVerifyPassword) {
-        Timber.d("create new secure shared preferences");
+        log(Log.DEBUG, TAG, "create new secure shared preferences");
         this.sharedPreferences = sharedPreferences;
         this.factory = encryptionProtocolFactory;
         this.recoveryPolicy = recoveryPolicy;
@@ -92,7 +96,7 @@ public final class SecureSharedPreferences implements ArmadilloSharedPreferences
         String prefSaltBase64 = sharedPreferences.getString(prefSaltContentKey, null);
         byte[] prefSalt;
         if (prefSaltBase64 == null) {
-            Timber.v("create new preferences random salt");
+            log(Log.VERBOSE, TAG, "create new preferences random salt");
             byte[] generatedPrefSalt = Bytes.random(PREFERENCES_SALT_LENGTH_BYTES, secureRandom).array();
             try {
                 prefSalt = Bytes.wrap(generatedPrefSalt).copy().array();


### PR DESCRIPTION
I would like to include this library in an SDK as a fallback to [Googles Keystore Wrapper](https://developer.android.com/jetpack/androidx/releases/security)… Especially since OEMs phone models have broken the keystone… somehow, at least  to the best I can tell, not an expert here 😅  

So, I would like to avoid having to require Timber in an SDK if possible. I've just removed it from the Armadillo module here, if you prefer to keep the logging I also made a logger [branch here](https://github.com/patrickfav/armadillo/compare/master...marukami:logger)